### PR TITLE
feat: add WebRTC signaling channel

### DIFF
--- a/js/rtc-signal.js
+++ b/js/rtc-signal.js
@@ -1,0 +1,41 @@
+import { sb } from './supabase.js';
+
+export function openRoomChannel(roomId, { onSignal, onPresence }) {
+  // Можно держать 1 канал на комнату и для сигналинга, и для postgres_changes (чата)
+  const channel = sb.channel(`room:${roomId}`, {
+    config: { presence: { key: crypto.randomUUID() } } // уникальный ключ участника
+  });
+
+  // PRESENCE: кто в комнате
+  channel.on('presence', { event: 'sync' }, () => {
+    const state = channel.presenceState(); // { <presence_key>: [{...}, ...], ... }
+    onPresence?.(state);
+  });
+
+  // BROADCAST: сигналинг для SDP/ICE
+  channel.on('broadcast', { event: 'signal' }, ({ payload }) => {
+    // payload = { type: 'offer'|'answer'|'ice', data: any, from?: string }
+    onSignal?.(payload);
+  });
+
+  // Подписка
+  channel.subscribe(async status => {
+    if (status === 'SUBSCRIBED') {
+      // объявиться в presence
+      await channel.track({ at: Date.now() });
+    }
+  });
+
+  // Ф-я отправки сигналов
+  function sendSignal(payload) {
+    // НИЧЕГО не пишем в БД — чисто эфемерные сообщения
+    channel.send({ type: 'broadcast', event: 'signal', payload });
+  }
+
+  // Закрытие канала
+  function close() {
+    sb.removeChannel(channel);
+  }
+
+  return { channel, sendSignal, close };
+}


### PR DESCRIPTION
## Summary
- add `openRoomChannel` utility for Supabase-based signaling

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dff3a418832c8202163253555499