### PR TITLE
feat: add sendMessage helper

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,11 @@
+import { sb } from './supabase.js';
+
+export async function sendMessage(roomId, content, author = 'guest') {
+  const { data, error } = await sb
+    .from('messages')
+    .insert([{ room_id: roomId, content, author }])
+    .select()
+    .single();
+  if (error) throw error;
+  return data; // {id, room_id, content, author, created_at}
+}


### PR DESCRIPTION
## Summary
- implement sendMessage to store chat messages in Supabase

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e0f77af8832c84d1ff7593291a8a