### PR TITLE
refactor chat utility

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -1,44 +1,5 @@
 import { sb } from './supabase.js';
 
-export async function loadMessages(roomId, limit = 50) {
-  const { data, error } = await sb
-    .from('messages')
-    .select()
-    .eq('room_id', roomId)
-    .order('created_at', { ascending: true })
-    .limit(limit);
-  if (error) throw error;
-  return data ?? [];
-}
-
-export async function sendMessage(roomId, content, author = 'guest') {
-  const { data, error } = await sb
-    .from('messages')
-    .insert([{ room_id: roomId, content, author }])
-    .select()
-    .single();
-  if (error) throw error;
-  return data; // {id, room_id, content, author, created_at}
-}
-
-
-export function subscribeMessages(roomId, callback, channel) {
-  const ch = channel ?? sb.channel(`messages:${roomId}`);
-  ch.on(
-    'postgres_changes',
-    {
-      event: 'INSERT',
-      schema: 'public',
-      table: 'messages',
-      filter: `room_id=eq.${roomId}`
-    },
-    payload => callback(payload.new)
-  );
-  if (!channel) ch.subscribe();
-  return ch;
-}
-
-
 export async function loadMessages(roomId, limit = 100) {
   const { data, error } = await sb
     .from('messages')
@@ -50,6 +11,15 @@ export async function loadMessages(roomId, limit = 100) {
   return (data ?? []).reverse();
 }
 
+export async function sendMessage(roomId, content, author = 'guest') {
+  const { data, error } = await sb
+    .from('messages')
+    .insert([{ room_id: roomId, content, author }])
+    .select()
+    .single();
+  if (error) throw error;
+  return data; // {id, room_id, content, author, created_at}
+}
 
 export function subscribeMessages(roomId, onInsert, channel) {
   // Если канал не передали — создадим свой (но лучше передавать общий канал комнаты)
@@ -72,3 +42,4 @@ export function subscribeMessages(roomId, onInsert, channel) {
 
   // Если используем общий канал — возвращаем "пустую" отписку (закроете общий канал снаружи)
   return () => {};
+}


### PR DESCRIPTION
## Summary
- remove duplicate functions in chat.js and streamline API
- fix missing bracket and ensure unsubscribe helper

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/chat.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9e8810bf0832c8de7b5dab34af29b