### PR TITLE
style: add base layout and theme styles

### DIFF
--- a/css/globals.css
+++ b/css/globals.css
@@ -1,0 +1,122 @@
+/* Base theme variables */
+:root {
+  --color-bg: #0a0a0a;
+  --color-surface: #1f1f1f;
+  --color-border: #333;
+  --color-text: #f5f5f5;
+  --color-primary: #3b82f6;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, sans-serif;
+}
+
+/* Layout containers */
+.layout-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.layout-stack {
+  display: flex;
+  flex-direction: column;
+}
+
+.layout-grid {
+  display: grid;
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+/* Message list */
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.message {
+  background: var(--color-surface);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.message.me {
+  align-self: flex-end;
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* Video tiles */
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.5rem;
+}
+
+.video-tile {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.video-tile video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Controls */
+button,
+.btn {
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+button:hover,
+.btn:hover {
+  background: #2563eb;
+}
+
+input,
+textarea,
+.input {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+}
+
+input:focus,
+textarea:focus,
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="theme-color" content="#0a0a0a" />
   <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="icon" href="/assets/icons/icon-192.png" />
+  <link rel="stylesheet" href="/css/globals.css" />
   <title>Facetime caller</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/@supabase/supabase-js@2"></script>


### PR DESCRIPTION
## Summary
- link global stylesheet in index
- add theme variables, layout helpers, and animations
- style message list, video grid, and dark-themed controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e90816f8832caf22191d699c15e3