### PR TITLE
Add audio-only toggle for video tracks

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,7 @@
 import { openRoomChannel } from './rtc-signal.js';
 import { loadMessages, sendMessage, subscribeMessages } from './chat.js';
 import * as rtc from './rtc.js';
+import './features/audio-only.js';
 
 function renderPresence() {}
 function renderMessages() {}

--- a/js/features/audio-only.js
+++ b/js/features/audio-only.js
@@ -1,0 +1,23 @@
+import { toggleVideo } from '../rtc.js';
+
+let videoEnabled = true;
+
+const btn = document.createElement('button');
+btn.id = 'audioOnlyBtn';
+btn.className =
+  'fixed bottom-4 right-4 bg-neutral-800 text-neutral-100 rounded-full p-3';
+
+function render() {
+  btn.textContent = videoEnabled ? '🎥' : '🎧';
+  btn.title = videoEnabled ? 'Выключить видео' : 'Включить видео';
+}
+
+btn.addEventListener('click', () => {
+  videoEnabled = !videoEnabled;
+  toggleVideo(videoEnabled);
+  render();
+});
+
+render();
+document.body.appendChild(btn);
+

--- a/js/rtc.js
+++ b/js/rtc.js
@@ -4,6 +4,7 @@ let pc;
 let sendSignalFn;
 let currentRoomId;
 let reconnectTimer;
+let localStream;
 
 function ensureVideo(id, muted = false) {
   let el = document.getElementById(id);
@@ -28,6 +29,16 @@ function scheduleReconnect() {
     reconnectTimer = null;
     if (currentRoomId) start(currentRoomId);
   }, 1000);
+}
+
+export function toggleVideo(enabled) {
+  localStream?.getVideoTracks().forEach(track => {
+    track.enabled = enabled;
+  });
+  const localVideo = document.getElementById('localVideo');
+  if (localVideo) {
+    localVideo.style.display = enabled ? '' : 'none';
+  }
 }
 
 export async function start(roomId) {
@@ -59,7 +70,7 @@ export async function start(roomId) {
     }
   };
 
-  const localStream = await navigator.mediaDevices.getUserMedia({
+  localStream = await navigator.mediaDevices.getUserMedia({
     audio: true,
     video: true
   });


### PR DESCRIPTION
## Summary
- add `toggleVideo` to RTC module for enabling or disabling local video tracks
- add audio-only feature with UI button to toggle video and reflect state
- load audio-only feature from main app

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9efb8bfb4832c8b82d1dbebfea723