### PR TITLE
Add participants presence rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 </head>
 <body class="bg-neutral-950 text-neutral-100">
   <div id="app"></div>
+  <div id="participants"></div>
 
   <script type="module">
     import '/js/app.js';

--- a/js/app.js
+++ b/js/app.js
@@ -1,16 +1,19 @@
 import { openRoomChannel } from './rtc-signal.js';
 import { loadMessages, sendMessage, subscribeMessages } from './chat.js';
+import { renderPresence } from './ui.js';
 import * as rtc from './rtc.js';
 
-function renderPresence() {}
 function renderMessages() {}
 function appendMessage() {}
 function toast(msg) { console.error(msg); }
 
 export async function enterRoom(roomId) {
+  const participantsEl = document.querySelector('#participants');
   const { channel, sendSignal, close } = openRoomChannel(roomId, {
     onSignal: msg => rtc.onSignal?.(msg, sendSignal),
-    onPresence: state => renderPresence(state)
+    onPresence: state => {
+      if (participantsEl) participantsEl.innerHTML = renderPresence(state);
+    }
   });
 
   const history = await loadMessages(roomId, 100);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,6 @@
+export function renderPresence(state) {
+  const keys = Object.keys(state || {});
+  if (!keys.length) return '<p>Нет участников</p>';
+  const items = keys.map((_, idx) => `<li>Участник ${idx + 1}</li>`).join('');
+  return `<ul>${items}</ul>`;
+}


### PR DESCRIPTION
## Summary
- add participants placeholder to `index.html`
- implement `renderPresence` to format presence state
- wire presence updates into room channel to refresh DOM

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9efcb8f1c832c9408c1488960ace3