### PR TITLE
Add Telegram login Edge Function

### DIFF
--- a/functions/tg_login/index.ts
+++ b/functions/tg_login/index.ts
@@ -1,0 +1,115 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+import { SignJWT } from "https://deno.land/x/jose@v4.14.4/index.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json() as {
+      id: number;
+      username?: string;
+      photo_url?: string;
+      auth_date: number;
+      hash: string;
+      first_name?: string;
+      last_name?: string;
+    };
+
+    // Ensure auth_date is not older than 24 hours
+    const now = Math.floor(Date.now() / 1000);
+    if (!body.auth_date || now - Number(body.auth_date) > 60 * 60 * 24) {
+      return new Response("Auth date too old", { status: 401, headers: corsHeaders });
+    }
+
+    // Build data check string for signature verification
+    const dataCheckString = Object.entries(body)
+      .filter(([key]) => key !== "hash")
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${key}=${value}`)
+      .join("\n");
+
+    // Verify Telegram signature
+    const secret = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(Deno.env.get("BOT_TOKEN") ?? ""),
+    );
+    const key = await crypto.subtle.importKey(
+      "raw",
+      secret,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const signature = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      new TextEncoder().encode(dataCheckString),
+    );
+    const hmac = Array.from(new Uint8Array(signature))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    if (hmac !== body.hash) {
+      return new Response("Invalid hash", { status: 401, headers: corsHeaders });
+    }
+
+    const userKey = `tg:${body.id}`;
+    const profile = {
+      user_key: userKey,
+      telegram_id: body.id,
+      username: body.username ?? null,
+      display_name: [body.first_name, body.last_name].filter(Boolean).join(" ") || body.username || `tg_${body.id}`,
+      avatar_url: body.photo_url ?? null,
+    };
+
+    const upsertResp = await fetch(`${Deno.env.get("SUPABASE_URL")}/rest/v1/profiles`, {
+      method: "POST",
+      headers: {
+        apikey: Deno.env.get("SUPABASE_SERVICE_KEY") ?? "",
+        Authorization: `Bearer ${Deno.env.get("SUPABASE_SERVICE_KEY") ?? ""}`,
+        "Content-Type": "application/json",
+        Prefer: "resolution=merge-duplicates",
+      },
+      body: JSON.stringify(profile),
+    });
+
+    if (!upsertResp.ok) {
+      const text = await upsertResp.text();
+      throw new Error(`Profile upsert failed: ${upsertResp.status} ${text}`);
+    }
+
+    const payload = {
+      sub: userKey,
+      role: "authenticated",
+      telegram_id: String(body.id),
+      username: body.username ?? null,
+      exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30,
+    };
+
+    const access_token = await new SignJWT(payload)
+      .setProtectedHeader({ alg: "HS256" })
+      .sign(new TextEncoder().encode(Deno.env.get("SUPABASE_JWT_SECRET") ?? ""));
+
+    return new Response(
+      JSON.stringify({ access_token, profile }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  } catch (err) {
+    console.error(err);
+    return new Response("Internal Server Error", {
+      status: 500,
+      headers: corsHeaders,
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add a `/tg_login` Edge Function in `functions/tg_login/index.ts`
- verify Telegram signature, check `auth_date`, upsert profile in Supabase, and return custom JWT
- include CORS handling and basic error handling

## Testing
- `deno fmt functions/tg_login/index.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fdd8f834832caf7f1376b5b100b7