### PR TITLE
Add Telegram bot token configuration

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,13 @@
+/**
+ * Copy to config.js and replace placeholders for local development.
+ * In production, provide these values via environment variables.
+ */
+export const ICE_SERVERS = [
+  { urls: ['stun:stun.l.google.com:19302'] }, // Example STUN server
+  // { urls: 'turns:turn.example.com:5349', username: 'user', credential: 'pass' }, // Example TURN server
+];
+
+export const SUPABASE_PROJECT_ID = process.env.SUPABASE_PROJECT_ID || '<your-project-id>';
+export const SUPABASE_URL = process.env.SUPABASE_URL || 'https://<your-project-ref>.supabase.co';
+export const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || '<your-anon-key>';
+export const TELEGRAM_BOT_TOKEN = '8338260347:AAFaqaEfiWkIMISuvoZW2FTk5yaHwgwWxj0';


### PR DESCRIPTION
## Summary
- add Telegram bot token to config

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a9ffb689a8832cbf807ae92695175c