### PR TITLE
feat: support external auth token

### DIFF
--- a/js/supabase.js
+++ b/js/supabase.js
@@ -1,3 +1,15 @@
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from '/config/config.js';
 
-export const sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const sb = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { persistSession: true, detectSessionInUrl: false },
+  global: { headers: {} }
+});
+
+export function setAuthToken(accessToken) {
+  sb.rest.headers = { ...sb.rest.headers, Authorization: `Bearer ${accessToken}` };
+  sb.realtime.setAuth(accessToken);
+  localStorage.setItem('sb_tg_token', accessToken);
+}
+
+const savedToken = localStorage.getItem('sb_tg_token');
+if (savedToken) setAuthToken(savedToken);


### PR DESCRIPTION
## Summary
- allow passing external auth token to Supabase client and persist it across sessions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa040d0128832c9eeb957e4161e6cd