### PR TITLE
use config for telegram bot username

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -10,3 +10,5 @@ export const ICE_SERVERS = [
 export const SUPABASE_PROJECT_ID = process.env.SUPABASE_PROJECT_ID || '<your-project-id>';
 export const SUPABASE_URL = process.env.SUPABASE_URL || 'https://<your-project-ref>.supabase.co';
 export const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || '<your-anon-key>';
+export const TELEGRAM_BOT_USERNAME = process.env.TELEGRAM_BOT_USERNAME || '<your-bot-username>';
+export const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || '<your-bot-token>';

--- a/config/config.js
+++ b/config/config.js
@@ -13,4 +13,8 @@ export const SUPABASE_URL =
 export const SUPABASE_ANON_KEY =
   process.env.SUPABASE_ANON_KEY ||
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNld2JlaWJmbmhzemh5d3NzYnRxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU5NjA4NzYsImV4cCI6MjA3MTUzNjg3Nn0.8krynDDOAxV12xkcgSBsQ-qxb3JrDysjQkzggFzPpPg';
-export const TELEGRAM_BOT_TOKEN = '8338260347:AAFaqaEfiWkIMISuvoZW2FTk5yaHwgwWxj0';
+export const TELEGRAM_BOT_USERNAME =
+  process.env.TELEGRAM_BOT_USERNAME || 'YOUR_BOT';
+export const TELEGRAM_BOT_TOKEN =
+  process.env.TELEGRAM_BOT_TOKEN ||
+  '8338260347:AAFaqaEfiWkIMISuvoZW2FTk5yaHwgwWxj0';

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
   <script type="module">
     import '/js/app.js';
     import { initTelegramAuthUI, isAuthenticated } from '/js/auth-tg.js';
+    import { TELEGRAM_BOT_USERNAME } from '/config/config.js';
 
     const loginRoot = document.getElementById('login-root');
     const app = document.getElementById('app');
@@ -44,7 +45,7 @@
       loginBtn.addEventListener('click', () => {
         loginBtn.remove();
         initTelegramAuthUI({
-          botUsername: 'YOUR_BOT',
+          botUsername: TELEGRAM_BOT_USERNAME,
           functionUrl: '/functions/v1/tg_login',
           containerId: 'login-root',
           onLogin: showApp


### PR DESCRIPTION
## Summary
- Load Telegram bot username from config instead of hardcoded placeholder
- Add Telegram bot settings to config templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c64f050832c82f56392944aa3b7