### PR TITLE
Configure Telegram bot credentials

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -7,8 +7,6 @@ export const ICE_SERVERS = [
   // { urls: 'turns:turn.example.com:5349', username: 'user', credential: 'pass' }, // Example TURN server
 ];
 // In browser builds `process` might be undefined; guard its usage
-const env = typeof process === 'object' && process.env ? process.env : {};
-
 const env = typeof process !== 'undefined' ? process.env : {};
 
 export const SUPABASE_PROJECT_ID = env.SUPABASE_PROJECT_ID || '<your-project-id>';

--- a/config/config.js
+++ b/config/config.js
@@ -7,8 +7,6 @@ export const ICE_SERVERS = [
   // { urls: 'turns:turn.example.com:5349', username: 'user', credential: 'pass' }, // Example TURN server
 ];
 // In a browser environment `process` may be undefined; read env vars safely
-const env = typeof process === 'object' && process.env ? process.env : {};
-
 const env = typeof process !== 'undefined' ? process.env : {};
 
 export const SUPABASE_PROJECT_ID = env.SUPABASE_PROJECT_ID || 'cewbeibfnhszhywssbtq';
@@ -18,7 +16,7 @@ export const SUPABASE_ANON_KEY =
   env.SUPABASE_ANON_KEY ||
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNld2JlaWJmbmhzemh5d3NzYnRxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU5NjA4NzYsImV4cCI6MjA3MTUzNjg3Nn0.8krynDDOAxV12xkcgSBsQ-qxb3JrDysjQkzggFzPpPg';
 export const TELEGRAM_BOT_USERNAME =
-  env.TELEGRAM_BOT_USERNAME || 'YOUR_BOT';
+  env.TELEGRAM_BOT_USERNAME || 'webf2fBot';
 export const TELEGRAM_BOT_TOKEN =
   env.TELEGRAM_BOT_TOKEN ||
   '8338260347:AAFaqaEfiWkIMISuvoZW2FTk5yaHwgwWxj0';


### PR DESCRIPTION
## Summary
- configure Telegram bot name and token
- clean duplicate env initialization in config files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa75578f94832cac1cfe2f8de0d032