### PR TITLE
Handle Telegram widget user object and show app after login

### DIFF
--- a/js/auth-tg.js
+++ b/js/auth-tg.js
@@ -94,7 +94,7 @@ export function initTelegramAuthUI(opts) {
   script.setAttribute('data-size', 'large');
   script.setAttribute('data-userpic', 'true');
   script.setAttribute('data-request-access', 'write');
-  script.setAttribute('data-onauth', 'onTelegramAuth');
+  script.setAttribute('data-onauth', 'onTelegramAuth(user)');
   wrap.appendChild(script);
 
   // Expose global callback for the widget
@@ -106,7 +106,12 @@ export function initTelegramAuthUI(opts) {
         localStorage.setItem('sb_tg_token', access_token);
       }
       await createClientWithToken(access_token);
-      if (typeof onLogin === 'function') onLogin(profile);
+      if (typeof onLogin === 'function') {
+        onLogin(profile);
+      } else if (typeof window.showApp === 'function') {
+        // Fallback: ensure the main app is revealed even if no onLogin callback
+        window.showApp();
+      }
     } catch (e) {
       console.error('Telegram auth failed:', e);
       if (typeof alert === 'function') alert('Не удалось войти через Telegram: ' + e.message);


### PR DESCRIPTION
## Summary
- Pass `user` to `onTelegramAuth` by updating Telegram widget `data-onauth` attribute
- After successful auth, call provided `onLogin` (or `showApp` fallback) to hide login screen and reveal the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7cf536c0832c87865e7938d4abb4