### PR TITLE
test: check Telegram auth callback attribute

### DIFF
--- a/js/auth-tg.js
+++ b/js/auth-tg.js
@@ -94,7 +94,7 @@ export function initTelegramAuthUI(opts) {
   script.setAttribute('data-size', 'large');
   script.setAttribute('data-userpic', 'true');
   script.setAttribute('data-request-access', 'write');
-  script.setAttribute('data-onauth', 'onTelegramAuth');
+  script.setAttribute('data-onauth', 'onTelegramAuth(user)');
   wrap.appendChild(script);
 
   // Expose global callback for the widget

--- a/test/auth-tg.test.js
+++ b/test/auth-tg.test.js
@@ -37,7 +37,11 @@ test('init and login in browser-like environment', async () => {
 
   const auth = await import('../js/auth-tg.js');
   auth.initTelegramAuthUI({ botUsername: 'bot', functionUrl: '/func', containerId: 'login-root' });
-  assert.ok(container.children.find(c => c.id === 'tg-login-wrap'));
+  const wrap = container.children.find(c => c.id === 'tg-login-wrap');
+  assert.ok(wrap);
+  const scriptEl = wrap.children && wrap.children.find(c => c.tagName === 'SCRIPT');
+  assert.ok(scriptEl);
+  assert.equal(scriptEl['data-onauth'], 'onTelegramAuth(user)');
   await window.onTelegramAuth({ id: 1 });
   assert.equal(auth.isAuthenticated(), true);
 });


### PR DESCRIPTION
## Summary
- ensure Telegram auth widget sets onAuth handler with user parameter
- test that script element exposes `data-onauth="onTelegramAuth(user)"`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7d9bdbd4832c9b57ea77cc96db9b