### PR TITLE
feat: improve telegram login error handling

### DIFF
--- a/js/auth-tg.js
+++ b/js/auth-tg.js
@@ -55,10 +55,23 @@ async function exchangeTelegramUser(functionUrl, tgUserPayload) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(tgUserPayload),
   });
+
+  const contentType = res.headers?.get?.('content-type') || '';
+  const text = await res.text();
+
   if (!res.ok) {
-    throw new Error(await res.text());
+    throw new Error(text || `HTTP ${res.status}`);
   }
-  return res.json();
+
+  if (!contentType.includes('application/json')) {
+    throw new Error(text || 'Invalid response from auth server');
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    throw new Error('Invalid JSON response');
+  }
 }
 
 /**

--- a/test/auth-tg.test.js
+++ b/test/auth-tg.test.js
@@ -33,7 +33,11 @@ test('init and login in browser-like environment', async () => {
   globalThis.window = { document };
   globalThis.localStorage = createLocalStorage();
   window.localStorage = localStorage;
-  globalThis.fetch = async () => ({ ok: true, json: async () => ({ access_token: 'abc', profile: {} }), text: async () => '' });
+  globalThis.fetch = async () => ({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    text: async () => JSON.stringify({ access_token: 'abc', profile: {} })
+  });
 
   const auth = await import('../js/auth-tg.js');
   auth.initTelegramAuthUI({ botUsername: 'bot', functionUrl: '/func', containerId: 'login-root' });


### PR DESCRIPTION
## Summary
- handle non-JSON responses from Telegram login function to avoid parsing errors
- adjust tests for new response handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa7e8e2c8c832c9dc860f25b75b763