### PR TITLE
fix: use full supabase function URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <script type="module">
     import '/js/app.js';
     import { initTelegramAuthUI, isAuthenticated } from '/js/auth-tg.js';
-    import { TELEGRAM_BOT_USERNAME } from '/config/config.js';
+    import { SUPABASE_URL, TELEGRAM_BOT_USERNAME } from '/config/config.js';
 
     const loginRoot = document.getElementById('login-root');
     const app = document.getElementById('app');
@@ -46,7 +46,7 @@
         loginBtn.remove();
         initTelegramAuthUI({
           botUsername: TELEGRAM_BOT_USERNAME,
-          functionUrl: '/functions/v1/tg_login',
+          functionUrl: `${SUPABASE_URL}/functions/v1/tg_login`,
           containerId: 'login-root',
           onLogin: showApp
         });


### PR DESCRIPTION
## Summary
- ensure Telegram auth uses Supabase project URL for edge function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa801e246c832cafc44639201c01c4