### PR TITLE
Use Supabase SDK for Telegram auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <script type="module">
     import '/js/app.js';
     import { initTelegramAuthUI, isAuthenticated } from '/js/auth-tg.js';
-    import { SUPABASE_URL, TELEGRAM_BOT_USERNAME } from '/config/config.js';
+    import { TELEGRAM_BOT_USERNAME } from '/config/config.js';
 
     const loginRoot = document.getElementById('login-root');
     const app = document.getElementById('app');
@@ -46,7 +46,7 @@
         loginBtn.remove();
         initTelegramAuthUI({
           botUsername: TELEGRAM_BOT_USERNAME,
-          functionUrl: `${SUPABASE_URL}/functions/v1/tg_login`,
+          functionName: 'tg_login',
           containerId: 'login-root',
           onLogin: showApp
         });

--- a/node_modules/@supabase/supabase-js/index.js
+++ b/node_modules/@supabase/supabase-js/index.js
@@ -1,7 +1,20 @@
 export function createClient(url, key, opts = {}) {
   return {
-    url, key, opts,
+    url,
+    key,
+    opts,
     realtime: { setAuth() {} },
-    rpc: async () => ({ error: null })
+    rpc: async () => ({ error: null }),
+    functions: {
+      async invoke(fn, invokeOpts = {}) {
+        const res = await fetch(fn, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(invokeOpts.body),
+        });
+        const data = await res.json();
+        return { data, error: null };
+      },
+    },
   };
 }

--- a/test/auth-tg.test.js
+++ b/test/auth-tg.test.js
@@ -33,14 +33,14 @@ test('init and login in browser-like environment', async () => {
   globalThis.window = { document };
   globalThis.localStorage = createLocalStorage();
   window.localStorage = localStorage;
-  globalThis.fetch = async () => ({
-    ok: true,
-    headers: { get: () => 'application/json' },
-    text: async () => JSON.stringify({ access_token: 'abc', profile: {} })
-  });
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ access_token: 'abc', profile: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
 
   const auth = await import('../js/auth-tg.js');
-  auth.initTelegramAuthUI({ botUsername: 'bot', functionUrl: '/func', containerId: 'login-root' });
+  auth.initTelegramAuthUI({ botUsername: 'bot', functionName: 'tg_login', containerId: 'login-root' });
   const wrap = container.children.find(c => c.id === 'tg-login-wrap');
   assert.ok(wrap);
   const scriptEl = wrap.children && wrap.children.find(c => c.tagName === 'SCRIPT');


### PR DESCRIPTION
## Summary
- replace manual fetch with Supabase JS `functions.invoke` in Telegram auth flow
- expose `functionName` option and update HTML and tests
- extend local Supabase stub with `functions.invoke`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa86d1e850832ca8f4f29b4d85ee5b